### PR TITLE
fix(deps): remove global dependencyDashboardApproval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,6 @@
   "platformAutomerge": false,
   "ignoreTests": false,
   "dependencyDashboard": true,
-  "dependencyDashboardApproval": true,
   "packageRules": [
     {
       "description": "Auto-merge non-major updates that pass tests",


### PR DESCRIPTION
Only major updates should require approval via the dependency dashboard. Non-major updates should create PRs automatically.