### PR TITLE
fix(deps): add npmDedupe to Renovate postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
   "platformAutomerge": false,
   "ignoreTests": false,
   "dependencyDashboard": true,
+  "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
       "description": "Auto-merge non-major updates that pass tests",


### PR DESCRIPTION
Ensures npm lockfiles are properly deduped after updates to prevent missing dependency errors during npm ci.