### PR TITLE
fix(ci): use npm install instead of npm ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
   # Frontend tests run on self-hosted runners with persistent disk storage.
   # npm packages are cached locally at ~/.npm and persist between runs.
-  # npm ci deletes node_modules but preserves ~/.npm cache, so downloads are avoided on subsequent runs.
+  # npm install auto-fixes lockfile mismatches from Renovate updates.
   test-frontend:
     name: Frontend Tests
     runs-on: self-hosted
@@ -53,7 +53,7 @@ jobs:
           NODE_INSTALL_DIR: ${{ runner.temp }}/node
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       
       - name: Build frontend
         run: npm run build
@@ -62,7 +62,7 @@ jobs:
         run: npx svelte-check --tsconfig ./tsconfig.json
 
   # E2E tests run on self-hosted runners with persistent disk storage.
-  # npm packages cached at ~/.npm persist between runs (npm ci preserves this cache).
+  # npm packages cached at ~/.npm persist between runs.
   # Playwright browsers are cached separately and managed by the cache action below.
   test-e2e:
     name: E2E Tests
@@ -90,7 +90,7 @@ jobs:
           NODE_INSTALL_DIR: ${{ runner.temp }}/node
       
       - name: Install frontend dependencies
-        run: npm ci
+        run: npm install
       
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
npm ci is too strict for Renovate PRs that have lockfile inconsistencies. npm install auto-fixes these issues while still installing correct versions.