### PR TITLE
fix(docker): use npm install instead of npm ci in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:22.20.0-alpine@sha256:cb3143549582cc5f74f26f0992cdef4a422b22128cb517f94173a5f910fa4ee7 AS build
 WORKDIR /app
 COPY frontend/package*.json ./
-RUN npm ci
+RUN npm install
 COPY frontend/ ./
 ENV NODE_ENV=production
 RUN npm run build


### PR DESCRIPTION
Consistent with CI workflow changes to handle Renovate lockfile inconsistencies.