### PR TITLE
fix: add 30s timeout to custom registry token client

### DIFF
--- a/backend/src/CrBrowser.Api/CustomOciRegistryClient.cs
+++ b/backend/src/CrBrowser.Api/CustomOciRegistryClient.cs
@@ -159,7 +159,7 @@ public sealed class CustomOciRegistryClient : OciRegistryClientBase
 
         try
         {
-            using var tokenClient = new HttpClient();
+            using var tokenClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
             using var tokenReq = new HttpRequestMessage(HttpMethod.Get, tokenUrl);
             using var tokenResp = await tokenClient.SendAsync(tokenReq, ct);
 


### PR DESCRIPTION
## Summary

The  method creates an  with no explicit timeout. When hitting  for unauthenticated pulls of non-Docker Hub images (e.g. ), the token request can hang until the test's cancellation fires (~2 min), causing  to fail with .

## Fix

Add a 30-second timeout to the token client so the failure is fast, deterministic, and handled gracefully by the existing  block (which already logs and returns ).

## Test

Re-run of the failing test from run  (Backend Tests > Integration > ).

**No other tests or workflows are affected.**