### PR TITLE
fix: handle HttpRequestException as retryable in OciRegistryClientBase

### DIFF
--- a/backend/src/CrBrowser.Api/OciRegistryClientBase.cs
+++ b/backend/src/CrBrowser.Api/OciRegistryClientBase.cs
@@ -134,7 +134,16 @@ public abstract class OciRegistryClientBase : IContainerRegistryClient
         if (!string.IsNullOrWhiteSpace(bearer))
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
 
-        var resp = await _http.SendAsync(req, ct);
+        HttpResponseMessage resp;
+        try
+        {
+            resp = await _http.SendAsync(req, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Network error requesting {Url}", relativeUrl);
+            return (null, true, false);
+        }
         
         _logger.LogInformation("HTTP {Method} {Url} -> {StatusCode}", req.Method, relativeUrl, (int)resp.StatusCode);
         


### PR DESCRIPTION
## What

Handle `HttpRequestException` (network-level errors like unreachable hosts) as retryable in `OciRegistryClientBase.SendAsync` rather than letting it propagate as an unhandled exception.

## Why

When quay.io is unreachable from CI (e.g., network routing issues in GitHub Actions runners), the `QuayClient_Should_Return_NotFound_For_Nonexistent_Image` integration test fails because:

1. The test calls `ListTagsPageAsync` expecting it to return a `RegistryResponse` with `Retryable = true` on network failure
2. `SendAsync` didn't catch `HttpRequestException`, so it propagated as an unhandled exception
3. xUnit treats unhandled exceptions as test failures

This is inherently racy — the test was only passing when quay.io was reachable enough to respond with an HTTP error (not a network error). Making `SendAsync` handle `HttpRequestException` as `Retryable: true` is the right fix, since transient network errors should be retryable by definition.

## How

Wrap `_http.SendAsync` in a try-catch that catches `HttpRequestException`, logs a warning, and returns `(null, true, false)` — the same retryable-but-not-failure pattern already used for 5xx/429/401 responses.

## Testing

`Backend Tests` job (which was failing) should now pass when quay.io is unreachable — network errors will be classified as retryable rather than causing test failure.